### PR TITLE
Add Get-Set DrawBuild CallIn

### DIFF
--- a/rts/Game/UI/GuiHandler.cpp
+++ b/rts/Game/UI/GuiHandler.cpp
@@ -3936,7 +3936,8 @@ void CGuiHandler::DrawMapStuff(bool onMiniMap)
 		assert(buildeeDef != nullptr);
 
 		if (!buildInfoQueue.empty()) {
-			unitDrawer->SetupShowUnitBuildSquares(onMiniMap, true);
+			if (drawBuildGrid || onMiniMap)
+				unitDrawer->SetupShowUnitBuildSquares(onMiniMap, true);
 
 			// first pass; grid squares
 			for (const BuildInfo& bi: buildInfoQueue) {
@@ -3954,26 +3955,28 @@ void CGuiHandler::DrawMapStuff(bool onMiniMap)
 						}
 					}
 				}
-
-				if (unitDrawer->ShowUnitBuildSquares(bi, buildCommands, true)) {
-					buildColors.emplace_back(0.7f, 1.0f, 1.0f, 0.4f); // yellow
-				} else {
-					buildColors.emplace_back(1.0f, 0.5f, 0.5f, 0.4f); // red
+				if (drawBuildGrid || onMiniMap){
+					if (unitDrawer->ShowUnitBuildSquares(bi, buildCommands, true)) {
+						buildColors.emplace_back(0.7f, 1.0f, 1.0f, 0.4f); // yellow
+					} else {
+						buildColors.emplace_back(1.0f, 0.5f, 0.5f, 0.4f); // red
+					}
 				}
 			}
+			if (drawBuildGrid || onMiniMap){
+				unitDrawer->ResetShowUnitBuildSquares(onMiniMap, true);
+				unitDrawer->SetupShowUnitBuildSquares(onMiniMap, false);
 
-			unitDrawer->ResetShowUnitBuildSquares(onMiniMap, true);
-			unitDrawer->SetupShowUnitBuildSquares(onMiniMap, false);
+				// second pass; water-depth indicator lines
+				for (const BuildInfo& bi: buildInfoQueue) {
+					unitDrawer->ShowUnitBuildSquares(bi, {}, false);
+				}
 
-			// second pass; water-depth indicator lines
-			for (const BuildInfo& bi: buildInfoQueue) {
-				unitDrawer->ShowUnitBuildSquares(bi, {}, false);
-			}
-
-			unitDrawer->ResetShowUnitBuildSquares(onMiniMap, false);
+				unitDrawer->ResetShowUnitBuildSquares(onMiniMap, false);
+			}				
 		}
 
-		if (!onMiniMap && !buildInfoQueue.empty()) {
+		if (drawBuildGhost && !onMiniMap && !buildInfoQueue.empty()) {
 			// render a pending line/area-build queue
 			assert((buildInfoQueue.front()).def == (buildInfoQueue.back()).def);
 			assert(buildInfoQueue.size() == buildColors.size());

--- a/rts/Game/UI/GuiHandler.h
+++ b/rts/Game/UI/GuiHandler.h
@@ -98,6 +98,10 @@ public:
 	void SetDrawSelectionInfo(bool dsi) { drawSelectionInfo = dsi; }
 	bool GetDrawSelectionInfo() const { return drawSelectionInfo; }
 
+	void SetDrawBuild(bool grid, bool ghost) { drawBuildGrid = grid; drawBuildGhost = ghost; }
+	bool GetDrawBuildGrid() const { return drawBuildGrid; }
+	bool GetDrawBuildGhost() const { return drawBuildGhost; }
+
 	void SetBuildFacing(unsigned int facing) { buildFacing = facing % NUM_FACINGS; }
 	void SetBuildSpacing(int spacing) { buildSpacing = std::max(spacing, 0); }
 
@@ -182,7 +186,8 @@ public:
 	int inCommand = -1;
 	int buildFacing = FACING_SOUTH;
 	int buildSpacing = 0;
-
+	bool drawBuildGrid = true;
+	bool drawBuildGhost = true;
 private:
 	int maxPage = 0;
 	int activePage = 0;


### PR DESCRIPTION
Getter/Setter CallIn controlling the main map drawing of build grid and build ghost (don't change build grid drawn on minimap).
For the purpose of removing them when one want to draw customized elevation of ghost/grid along with auto terraforming widget.
usage:
 Spring.SetDrawBuild(bool grid, bool ghost)
 Spring.GetDrawBuild() -> bool grid, bool ghost